### PR TITLE
Local commands

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,7 @@ setup(
     # https://packaging.python.org/en/latest/requirements.html
     # install_requires=['peppercorn'],
     install_requires=[
-        'PyYAML >= 3.11, < 4',
+        'ruamel.yaml >= 0.11.14, < 1',
         'fake-factory >= 0.5.7, < 1',
         'docker-py >= 1.8.1, < 2',
     ],

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     # Versions should comply with PEP440.  For a discussion on single-sourcing
     # the version across setup.py and the project code, see
     # https://packaging.python.org/en/latest/single_source_version.html
-    version='0.2.0',
+    version='0.2.1',
 
     description='Tool for working with Docker containers',
     long_description=long_description,

--- a/wundertool/cli.py
+++ b/wundertool/cli.py
@@ -12,14 +12,28 @@ from wundertool.settings import local_commands_file
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument('command')
-    args = parser.parse_args()
-    try:
-        func = getattr(wundertool.commands, args.command)
-    except AttributeError:
-        # TODO: Print usage instructions here.
-        print("Command not found!")
-    except:
-        print("Unexpected error:", sys.exc_info()[0])
-        raise
+    args, unknown = parser.parse_known_args()
+    if not exec_local_command(args.command, unknown):
+        try:
+            func = getattr(wundertool.commands, args.command)
+        except AttributeError:
+            # TODO: Print usage instructions here.
+            print("Command not found!")
+        except:
+            print("Unexpected error:", sys.exc_info()[0])
+            raise
+        else:
+            func()
+
+def exec_local_command(command, args):
+    commands = wundertool.helpers.get_config(local_commands_file)
+    if commands:
+        if command in commands:
+            config = wundertool.helpers.get_cmd_config(command, commands.get(command))
+            if config.get("type") == "shell":
+                wundertool.commands.shell(config.get("entrypoint"), args)
+                return True
+            else:
+                raise NotImplementedError("Invalid command type.")
     else:
-        func()
+        return False

--- a/wundertool/cli.py
+++ b/wundertool/cli.py
@@ -6,6 +6,9 @@ import argparse
 import wundertool.helpers
 import wundertool.commands
 
+# Get the global settings variables.
+from wundertool.settings import local_commands_file
+
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument('command')

--- a/wundertool/cli.py
+++ b/wundertool/cli.py
@@ -25,6 +25,13 @@ def main():
         else:
             func()
 
+# TODO: Extend this to allow storing local commands per user at ~/.wundertool/commands.yml
+# TODO: Maybe allow some settings at ~/.wundertool/settings.yml or maybe even
+# divide the settings even more to wundertool/project.yml
+# TODO: Implement a global init function to init ~/.wundertool settings.
+# TODO: Global ~/.wundertool/settings.yml should have configuration option
+# where one can define wether global or local settings should be preferred
+# (this allows one to always use global shell for example even if there is one include in the project)
 def exec_local_command(command, args):
     commands = wundertool.helpers.get_config(local_commands_file)
     if commands:

--- a/wundertool/cli.py
+++ b/wundertool/cli.py
@@ -32,6 +32,8 @@ def main():
 # TODO: Global ~/.wundertool/settings.yml should have configuration option
 # where one can define wether global or local settings should be preferred
 # (this allows one to always use global shell for example even if there is one include in the project)
+# TODO: Allow running of shell command and local commands by binding pwd to the container
+# so that no project is needed and no project or user specific settings is needed.
 def exec_local_command(command, args):
     commands = wundertool.helpers.get_config(local_commands_file)
     if commands:

--- a/wundertool/commands.py
+++ b/wundertool/commands.py
@@ -53,9 +53,10 @@ def cleanup():
         _docker("rm", containers)
 
 # Start a developer shell mapping source and linking to containers of the project.
-# TODO: Change this so that each shell name is unique so that we can run multiple shells at once.
+# TODO: Change this so that each shell name is unique so that we can run multiple shells at once. Maybe consider name from entrypoint.
 # TODO: Add host volume project mount to this command so that it automatically always mounts the project folder to /app/project
 # TODO: Add host volume pwd mount to this command so that it automatically always mounts the pwd to /app/pwd
+# TODO: Consider binding ~/.ssh etc. folders from the host. Maybe allow configuring this?
 def shell(entrypoint=False, args=[]):
     settings = wundertool.helpers.get_config()
     cli = docker.Client()

--- a/wundertool/helpers.py
+++ b/wundertool/helpers.py
@@ -8,10 +8,12 @@ import yaml
 # Use faker to create random project names.
 import faker
 
-# Define some multi-use variables.
-pwd = os.getcwd()
-settings_path = "wundertool"
-settings_main_file = settings_path + "/settings.yml"
+# Get the global settings variables.
+from wundertool.settings import pwd
+from wundertool.settings import settings_path
+from wundertool.settings import settings_main_file
+from wundertool.settings import local_commands_file
+from wundertool.settings import default_command_config
 
 # General function for confirming before continuing.
 def confirm(prompt, assume=False, reminder=False, retries=3):

--- a/wundertool/helpers.py
+++ b/wundertool/helpers.py
@@ -42,6 +42,8 @@ def confirm(prompt, assume=False, reminder=False, retries=3):
 def usage():
     print("This is how you should use the tool.")
 
+# TODO: Add comments to the created settings now that it's possible with
+# ruamel.yaml, see http://yaml.readthedocs.io/en/latest/example.html
 def create_example(settings_file=False, type="settings"):
     if not settings_file:
         create_example(settings_main_file)

--- a/wundertool/settings.py
+++ b/wundertool/settings.py
@@ -1,0 +1,10 @@
+
+# Needed system modules.
+import os
+
+# Set the global variables.
+pwd = os.getcwd()
+settings_path = "wundertool"
+settings_main_file = settings_path + "/settings.yml"
+local_commands_file = settings_path + "/commands.yml"
+default_command_config = {"type": "shell"}

--- a/wundertool/settings.py
+++ b/wundertool/settings.py
@@ -8,3 +8,5 @@ settings_path = "wundertool"
 settings_main_file = settings_path + "/settings.yml"
 local_commands_file = settings_path + "/commands.yml"
 default_command_config = {"type": "shell"}
+# TODO: Implement the usage of this.
+default_shell = "quay.io/wunder/wundertools-image-fuzzy-developershell"


### PR DESCRIPTION
Added the concept of local (per project for now, but should be extended to allow per user commands too) commands (defined in `wundertool/commands.yml`) of type shell (only one type for now) which allows one to run a command inside the defined shell container (defined in `wundertool/settings.yml`) passing in all the given arguments. With this it's possible to define commands that allow one to run drush inside the shell container for example like this:

```
wundertool drush st
```

By default commands are expected to be binaries in /usr/bin/ but the binary can be defined with the entrypoint option in the command definition in `wundertool/commands.yml`.

Example of the `wundertool/settings.yml` and `wundertool/commands.yml` can be created with:

```
wundertool init
```

_Note: This command doesn't override existing settings like `wundertool/settings.yml`, but creates new configuration like `wundertool/commands.yml` if it's missing._
